### PR TITLE
Fixed Webhook PHP Validation Example

### DIFF
--- a/docs/notifications_webhooks.md
+++ b/docs/notifications_webhooks.md
@@ -22,7 +22,7 @@ Here is a minimal example using PHP:
 ```php
 <?php
 
-$v = $_SERVER['HTTP_VALIDATION_TOKEN'] || '';
+$v = isset($_SERVER['HTTP_VALIDATION_TOKEN']) ? $_SERVER['HTTP_VALIDATION_TOKEN'] : '';
 
 if (strlen($v)>0) {
   header("Validation-Token: {$v}");


### PR DESCRIPTION
Updated example to set $v as a string instead of a boolean