### PR TITLE
Add client_id as a required parameter for the /restapi/oauth/token API

### DIFF
--- a/docs/oauth.md
+++ b/docs/oauth.md
@@ -118,6 +118,7 @@ The step-by-step details of this flow are explained below.
 	| ------------------- | -------- | ----------- |
     | `grant_type`        | string   | Required. Must be set to `authorization_code` for authorization code flow |
     | `code`              | string   | Required. Provide your authorization code received in the previous step |
+    | `client_id`         | string   | Required. Enter your application key (Production or Sandbox) here |
     | `redirect_uri`      | URI      | Required. This is a callback URI which determines where the response is sent. The value of this parameter must exactly match one of the URIs you have provided for your app upon registration. |
     | `access_token_ttl`  | integer  | Optional. Access token lifetime in seconds; the possible values are from 600 sec (10 min) to 3600 sec (1 hour). The default value is 3600 sec. If the value specified exceeds the default one, the default value is set. If the value specified is less than 600 seconds, the minimum value (600 sec) is set |
     | `refresh_token_ttl` | integer  | Optional. Refresh token lifetime in seconds. The default value depends on the client application, but as usual it equals to 7 days. If the value specified exceeds the default one, the default value is applied


### PR DESCRIPTION
This returns an error when `client_id` is not included:
```
$ curl 'https://platform.devtest.ringcentral.com/restapi/oauth/token' \
>     -X POST \
>     --header 'Content-Type: application/x-www-form-urlencoded' \
>     -d 'grant_type=authorization_code&code=<redacted>&redirect_uri=http://localhost:5000/oauth'
{
  "error" : "invalid_client",
  "error_description" : "Client authentication is required",
  "errors" : [ {
    "errorCode" : "OAU-123",
    "message" : "Client authentication is required"
  } ]
}
```

This successfully returns a token when `client_id` is included:
```
$ curl 'https://platform.devtest.ringcentral.com/restapi/oauth/token' \
>     -X POST \
>     --header 'Content-Type: application/x-www-form-urlencoded' \
>     -d 'grant_type=authorization_code&code=<redacted>&redirect_uri=http://localhost:5000/oauth&client_id=<redacted>'
{
  "access_token" : <redacted>,
  "token_type" : "bearer",
  "expires_in" : 2717,
  "refresh_token" : <redacted>,
  "refresh_token_expires_in" : 603917,
  "scope" : "RingOut SMS",
  "owner_id" : <redacted>,
  "endpoint_id" : <redacted>
}
```