### PR TITLE
Fixed DPW-7059 - Update links refer to Publishing App Page

### DIFF
--- a/docs/authentication/quick-start/authorization-flow/node.md
+++ b/docs/authentication/quick-start/authorization-flow/node.md
@@ -247,4 +247,4 @@ $ node index.js
 
 ## Publish Your App
 
-Congratulations on creating your first RingCentral application. The last step is to publish your application. We recommend [going through this process](../basics/publish) for your first application so you can understand the steps to take in the future, but also to come to appreciate the care taken by RingCentral to ensure that only high-quality apps are allowed into our production environment.
+Congratulations on creating your first RingCentral application. The last step is to publish your application. We recommend [going through this process](../../../basics/app-gallery.md) for your first application so you can understand the steps to take in the future, but also to come to appreciate the care taken by RingCentral to ensure that only high-quality apps are allowed into our production environment.

--- a/docs/authentication/quick-start/authorization-flow/php.md
+++ b/docs/authentication/quick-start/authorization-flow/php.md
@@ -235,4 +235,4 @@ $ php -S localhost:5000
 
 ## Publish Your App
 
-Congratulations on creating your first RingCentral application. The last step is to publish your application. We recommend [going through this process](../basics/publish) for your first application so you can understand the steps to take in the future, but also to come to appreciate the care taken by RingCentral to ensure that only high-quality apps are allowed into our production environment.
+Congratulations on creating your first RingCentral application. The last step is to publish your application. We recommend [going through this process](../../../basics/app-gallery.md) for your first application so you can understand the steps to take in the future, but also to come to appreciate the care taken by RingCentral to ensure that only high-quality apps are allowed into our production environment.

--- a/docs/authentication/quick-start/authorization-flow/python.md
+++ b/docs/authentication/quick-start/authorization-flow/python.md
@@ -199,4 +199,4 @@ $ FLASK_APP=index.py flask run
 
 ## Publish Your App
 
-Congratulations on creating your first RingCentral application. The last step is to publish your application. We recommend [going through this process](../basics/publish) for your first application so you can understand the steps to take in the future, but also to come to appreciate the care taken by RingCentral to ensure that only high-quality apps are allowed into our production environment.
+Congratulations on creating your first RingCentral application. The last step is to publish your application. We recommend [going through this process](../../../basics/app-gallery.md) for your first application so you can understand the steps to take in the future, but also to come to appreciate the care taken by RingCentral to ensure that only high-quality apps are allowed into our production environment.

--- a/docs/authentication/quick-start/password-flow/c-sharp.md
+++ b/docs/authentication/quick-start/password-flow/c-sharp.md
@@ -97,4 +97,4 @@ You are almost done. Now run your app from Visual Studio.
 
 ## Publish Your App
 
-Congratulations on creating your first RingCentral application. The last step is to publish your application. We recommend [going through this process](../basics/publish) for your first application so you can understand the steps to take in the future, but also to come to appreciate the care taken by RingCentral to ensure that only high-quality apps are allowed into our production environment.
+Congratulations on creating your first RingCentral application. The last step is to publish your application. We recommend [going through this process](../../../basics/app-gallery.md) for your first application so you can understand the steps to take in the future, but also to come to appreciate the care taken by RingCentral to ensure that only high-quality apps are allowed into our production environment.

--- a/docs/authentication/quick-start/password-flow/php.md
+++ b/docs/authentication/quick-start/password-flow/php.md
@@ -89,4 +89,4 @@ $ php fax.php
 
 ## Publish Your App
 
-Congratulations on creating your first RingCentral application. The last step is to publish your application. We recommend [going through this process](../basics/publish) for your first application so you can understand the steps to take in the future, but also to come to appreciate the care taken by RingCentral to ensure that only high-quality apps are allowed into our production environment.
+Congratulations on creating your first RingCentral application. The last step is to publish your application. We recommend [going through this process](../../../basics/app-gallery.md) for your first application so you can understand the steps to take in the future, but also to come to appreciate the care taken by RingCentral to ensure that only high-quality apps are allowed into our production environment.

--- a/docs/authentication/quick-start/password-flow/python.md
+++ b/docs/authentication/quick-start/password-flow/python.md
@@ -90,4 +90,4 @@ $ python fax.py
 
 ## Publish Your App
 
-Congratulations on creating your first RingCentral application. The last step is to publish your application. We recommend [going through this process](../basics/publish) for your first application so you can understand the steps to take in the future, but also to come to appreciate the care taken by RingCentral to ensure that only high-quality apps are allowed into our production environment.
+Congratulations on creating your first RingCentral application. The last step is to publish your application. We recommend [going through this process](../../../basics/app-gallery.md) for your first application so you can understand the steps to take in the future, but also to come to appreciate the care taken by RingCentral to ensure that only high-quality apps are allowed into our production environment.

--- a/docs/call-log/quick-start/c-sharp.md
+++ b/docs/call-log/quick-start/c-sharp.md
@@ -95,4 +95,4 @@ You are almost done. Now run your app from Visual Studio.
 
 ## Publish Your App
 
-Congratulations on creating your first RingCentral application. The last step is to publish your application. We recommend [going through this process](../basics/publish) for your first application so you can understand the steps to take in the future, but also to come to appreciate the care taken by RingCentral to ensure that only high-quality apps are allowed into our production environment.
+Congratulations on creating your first RingCentral application. The last step is to publish your application. We recommend [going through this process](../../basics/app-gallery.md) for your first application so you can understand the steps to take in the future, but also to come to appreciate the care taken by RingCentral to ensure that only high-quality apps are allowed into our production environment.

--- a/docs/call-log/quick-start/explorer.md
+++ b/docs/call-log/quick-start/explorer.md
@@ -42,4 +42,4 @@ TODO
 
 ## Publish Your App
 
-Congradulations on creating your first RingCentral application. The last step is to publish your application. We recommend [going through this process](../basics/publish) for your first application so you can understand the steps to take in the future, but also to come to appreciate the care taken by RingCentral to ensure that only high-quality apps are allowed into our production environment.
+Congradulations on creating your first RingCentral application. The last step is to publish your application. We recommend [going through this process](../../basics/app-gallery.md) for your first application so you can understand the steps to take in the future, but also to come to appreciate the care taken by RingCentral to ensure that only high-quality apps are allowed into our production environment.

--- a/docs/call-log/quick-start/node.md
+++ b/docs/call-log/quick-start/node.md
@@ -94,4 +94,4 @@ $ node fax.js
 
 ## Publish Your App
 
-Congratulations on creating your first RingCentral application. The last step is to publish your application. We recommend [going through this process](../basics/publish) for your first application so you can understand the steps to take in the future, but also to come to appreciate the care taken by RingCentral to ensure that only high-quality apps are allowed into our production environment.
+Congratulations on creating your first RingCentral application. The last step is to publish your application. We recommend [going through this process](../../basics/app-gallery.md) for your first application so you can understand the steps to take in the future, but also to come to appreciate the care taken by RingCentral to ensure that only high-quality apps are allowed into our production environment.

--- a/docs/call-log/quick-start/php.md
+++ b/docs/call-log/quick-start/php.md
@@ -84,4 +84,4 @@ $ php calllog.php
 
 ## Publish Your App
 
-Congratulations on creating your first RingCentral application. The last step is to publish your application. We recommend [going through this process](../basics/publish) for your first application so you can understand the steps to take in the future, but also to come to appreciate the care taken by RingCentral to ensure that only high-quality apps are allowed into our production environment.
+Congratulations on creating your first RingCentral application. The last step is to publish your application. We recommend [going through this process](../../basics/app-gallery.md) for your first application so you can understand the steps to take in the future, but also to come to appreciate the care taken by RingCentral to ensure that only high-quality apps are allowed into our production environment.

--- a/docs/call-log/quick-start/python.md
+++ b/docs/call-log/quick-start/python.md
@@ -80,4 +80,4 @@ $ python calllog.py
 
 ## Publish Your App
 
-Congratulations on creating your first RingCentral application. The last step is to publish your application. We recommend [going through this process](../basics/publish) for your first application so you can understand the steps to take in the future, but also to come to appreciate the care taken by RingCentral to ensure that only high-quality apps are allowed into our production environment.
+Congratulations on creating your first RingCentral application. The last step is to publish your application. We recommend [going through this process](../../basics/app-gallery.md) for your first application so you can understand the steps to take in the future, but also to come to appreciate the care taken by RingCentral to ensure that only high-quality apps are allowed into our production environment.

--- a/docs/fax/quick-start/c-sharp.md
+++ b/docs/fax/quick-start/c-sharp.md
@@ -97,4 +97,4 @@ You are almost done. Now run your app from Visual Studio.
 
 ## Publish Your App
 
-Congratulations on creating your first RingCentral application. The last step is to publish your application. We recommend [going through this process](../basics/publish) for your first application so you can understand the steps to take in the future, but also to come to appreciate the care taken by RingCentral to ensure that only high-quality apps are allowed into our production environment.
+Congratulations on creating your first RingCentral application. The last step is to publish your application. We recommend [going through this process](../../basics/app-gallery.md) for your first application so you can understand the steps to take in the future, but also to come to appreciate the care taken by RingCentral to ensure that only high-quality apps are allowed into our production environment.

--- a/docs/fax/quick-start/explorer.md
+++ b/docs/fax/quick-start/explorer.md
@@ -42,4 +42,4 @@ TODO
 
 ## Publish Your App
 
-Congradulations on creating your first RingCentral application. The last step is to publish your application. We recommend [going through this process](../basics/publish) for your first application so you can understand the steps to take in the future, but also to come to appreciate the care taken by RingCentral to ensure that only high-quality apps are allowed into our production environment.
+Congradulations on creating your first RingCentral application. The last step is to publish your application. We recommend [going through this process](../../basics/app-gallery.md) for your first application so you can understand the steps to take in the future, but also to come to appreciate the care taken by RingCentral to ensure that only high-quality apps are allowed into our production environment.

--- a/docs/fax/quick-start/node.md
+++ b/docs/fax/quick-start/node.md
@@ -108,4 +108,4 @@ $ node fax.js
 
 ## Publish Your App
 
-Congratulations on creating your first RingCentral application. The last step is to publish your application. We recommend [going through this process](../basics/publish) for your first application so you can understand the steps to take in the future, but also to come to appreciate the care taken by RingCentral to ensure that only high-quality apps are allowed into our production environment.
+Congratulations on creating your first RingCentral application. The last step is to publish your application. We recommend [going through this process](../../basics/app-gallery.md) for your first application so you can understand the steps to take in the future, but also to come to appreciate the care taken by RingCentral to ensure that only high-quality apps are allowed into our production environment.

--- a/docs/fax/quick-start/php.md
+++ b/docs/fax/quick-start/php.md
@@ -89,4 +89,4 @@ $ php fax.php
 
 ## Publish Your App
 
-Congratulations on creating your first RingCentral application. The last step is to publish your application. We recommend [going through this process](../basics/publish) for your first application so you can understand the steps to take in the future, but also to come to appreciate the care taken by RingCentral to ensure that only high-quality apps are allowed into our production environment.
+Congratulations on creating your first RingCentral application. The last step is to publish your application. We recommend [going through this process](../../basics/app-gallery.md) for your first application so you can understand the steps to take in the future, but also to come to appreciate the care taken by RingCentral to ensure that only high-quality apps are allowed into our production environment.

--- a/docs/fax/quick-start/python.md
+++ b/docs/fax/quick-start/python.md
@@ -90,4 +90,4 @@ $ python fax.py
 
 ## Publish Your App
 
-Congratulations on creating your first RingCentral application. The last step is to publish your application. We recommend [going through this process](../basics/publish) for your first application so you can understand the steps to take in the future, but also to come to appreciate the care taken by RingCentral to ensure that only high-quality apps are allowed into our production environment.
+Congratulations on creating your first RingCentral application. The last step is to publish your application. We recommend [going through this process](../../basics/app-gallery.md) for your first application so you can understand the steps to take in the future, but also to come to appreciate the care taken by RingCentral to ensure that only high-quality apps are allowed into our production environment.

--- a/docs/meetings/quick-start/node.md
+++ b/docs/meetings/quick-start/node.md
@@ -96,7 +96,7 @@ $ node meetings.js
 
 ## Publish Your App
 
-Congratulations on creating your first RingCentral application. The last step is to publish your application. We recommend [going through this process](../basics/publish) for your first application so you can understand the steps to take in the future, but also to come to appreciate the care taken by RingCentral to ensure that only high-quality apps are allowed into our production environment.
+Congratulations on creating your first RingCentral application. The last step is to publish your application. We recommend [going through this process](../../basics/app-gallery.md) for your first application so you can understand the steps to take in the future, but also to come to appreciate the care taken by RingCentral to ensure that only high-quality apps are allowed into our production environment.
 
 ## Troubleshooting
 

--- a/docs/meetings/quick-start/php.md
+++ b/docs/meetings/quick-start/php.md
@@ -87,7 +87,7 @@ $ php meetings.php
 
 ## Publish Your App
 
-Congratulations on creating your first RingCentral application. The last step is to publish your application. We recommend [going through this process](../basics/publish) for your first application so you can understand the steps to take in the future, but also to come to appreciate the care taken by RingCentral to ensure that only high-quality apps are allowed into our production environment.
+Congratulations on creating your first RingCentral application. The last step is to publish your application. We recommend [going through this process](../../basics/app-gallery.md) for your first application so you can understand the steps to take in the future, but also to come to appreciate the care taken by RingCentral to ensure that only high-quality apps are allowed into our production environment.
 
 ## Troubleshooting
 

--- a/docs/meetings/quick-start/python.md
+++ b/docs/meetings/quick-start/python.md
@@ -85,7 +85,7 @@ $ python meetings.py
 
 ## Publish Your App
 
-Congratulations on creating your first RingCentral application. The last step is to publish your application. We recommend [going through this process](../basics/publish) for your first application so you can understand the steps to take in the future, but also to come to appreciate the care taken by RingCentral to ensure that only high-quality apps are allowed into our production environment.
+Congratulations on creating your first RingCentral application. The last step is to publish your application. We recommend [going through this process](../../basics/app-gallery.md) for your first application so you can understand the steps to take in the future, but also to come to appreciate the care taken by RingCentral to ensure that only high-quality apps are allowed into our production environment.
 
 ## Troubleshooting
 

--- a/docs/notifications/quick-start/pubnub/node.md
+++ b/docs/notifications/quick-start/pubnub/node.md
@@ -102,4 +102,4 @@ $ node pubnub-notification.js
 
 ## Publish Your App
 
-Congratulations on creating your first RingCentral application. The last step is to publish your application. We recommend [going through this process](../basics/publish) for your first application so you can understand the steps to take in the future, but also to come to appreciate the care taken by RingCentral to ensure that only high-quality apps are allowed into our production environment.
+Congratulations on creating your first RingCentral application. The last step is to publish your application. We recommend [going through this process](../../../basics/app-gallery.md) for your first application so you can understand the steps to take in the future, but also to come to appreciate the care taken by RingCentral to ensure that only high-quality apps are allowed into our production environment.

--- a/docs/notifications/quick-start/pubnub/php.md
+++ b/docs/notifications/quick-start/pubnub/php.md
@@ -84,4 +84,4 @@ $ php pubnub-notification.php
 
 ## Publish Your App
 
-Congratulations on creating your first RingCentral application. The last step is to publish your application. We recommend [going through this process](../basics/publish) for your first application so you can understand the steps to take in the future, but also to come to appreciate the care taken by RingCentral to ensure that only high-quality apps are allowed into our production environment.
+Congratulations on creating your first RingCentral application. The last step is to publish your application. We recommend [going through this process](../../../basics/app-gallery.md) for your first application so you can understand the steps to take in the future, but also to come to appreciate the care taken by RingCentral to ensure that only high-quality apps are allowed into our production environment.

--- a/docs/notifications/quick-start/pubnub/python.md
+++ b/docs/notifications/quick-start/pubnub/python.md
@@ -100,4 +100,4 @@ $ python pubnub_notification.py
 
 ## Publish Your App
 
-Congratulations on creating your first RingCentral application. The last step is to publish your application. We recommend [going through this process](../basics/publish) for your first application so you can understand the steps to take in the future, but also to come to appreciate the care taken by RingCentral to ensure that only high-quality apps are allowed into our production environment.
+Congratulations on creating your first RingCentral application. The last step is to publish your application. We recommend [going through this process](../../../basics/app-gallery.md) for your first application so you can understand the steps to take in the future, but also to come to appreciate the care taken by RingCentral to ensure that only high-quality apps are allowed into our production environment.

--- a/docs/notifications/quick-start/webhook/node.md
+++ b/docs/notifications/quick-start/webhook/node.md
@@ -139,4 +139,4 @@ $ node webhook-notification.js
 
 ## Publish Your App
 
-Congratulations on creating your first RingCentral application. The last step is to publish your application. We recommend [going through this process](../basics/publish) for your first application so you can understand the steps to take in the future, but also to come to appreciate the care taken by RingCentral to ensure that only high-quality apps are allowed into our production environment.
+Congratulations on creating your first RingCentral application. The last step is to publish your application. We recommend [going through this process](../../../basics/app-gallery.md) for your first application so you can understand the steps to take in the future, but also to come to appreciate the care taken by RingCentral to ensure that only high-quality apps are allowed into our production environment.

--- a/docs/notifications/quick-start/webhook/php.md
+++ b/docs/notifications/quick-start/webhook/php.md
@@ -115,4 +115,4 @@ $ php webhook-notification.php
 
 ## Publish Your App
 
-Congratulations on creating your first RingCentral application. The last step is to publish your application. We recommend [going through this process](../basics/publish) for your first application so you can understand the steps to take in the future, but also to come to appreciate the care taken by RingCentral to ensure that only high-quality apps are allowed into our production environment.
+Congratulations on creating your first RingCentral application. The last step is to publish your application. We recommend [going through this process](../../../basics/app-gallery.md) for your first application so you can understand the steps to take in the future, but also to come to appreciate the care taken by RingCentral to ensure that only high-quality apps are allowed into our production environment.

--- a/docs/notifications/quick-start/webhook/python.md
+++ b/docs/notifications/quick-start/webhook/python.md
@@ -90,4 +90,4 @@ $ python fax.py
 
 ## Publish Your App
 
-Congratulations on creating your first RingCentral application. The last step is to publish your application. We recommend [going through this process](../basics/publish) for your first application so you can understand the steps to take in the future, but also to come to appreciate the care taken by RingCentral to ensure that only high-quality apps are allowed into our production environment.
+Congratulations on creating your first RingCentral application. The last step is to publish your application. We recommend [going through this process](../../../basics/app-gallery.md) for your first application so you can understand the steps to take in the future, but also to come to appreciate the care taken by RingCentral to ensure that only high-quality apps are allowed into our production environment.

--- a/docs/sms/quick-start/c-sharp.md
+++ b/docs/sms/quick-start/c-sharp.md
@@ -94,4 +94,4 @@ You are almost done. Now run your app from Visual Studio.
 
 ## Publish Your App
 
-Congratulations on creating your first RingCentral application. The last step is to publish your application. We recommend [going through this process](../basics/publish) for your first application so you can understand the steps to take in the future, but also to come to appreciate the care taken by RingCentral to ensure that only high-quality apps are allowed into our production environment.
+Congratulations on creating your first RingCentral application. The last step is to publish your application. We recommend [going through this process](../../basics/app-gallery.md) for your first application so you can understand the steps to take in the future, but also to come to appreciate the care taken by RingCentral to ensure that only high-quality apps are allowed into our production environment.

--- a/docs/sms/quick-start/explorer.md
+++ b/docs/sms/quick-start/explorer.md
@@ -66,4 +66,4 @@ Click the "Try it out" button to send yourself an SMS. If it works, try doing th
 
 ## Publish Your App
 
-Congradulations on creating your first RingCentral application. The last step is to publish your application. We recommend [going through this process](../basics/publish) for your first application so you can understand the steps to take in the future, but also to come to appreciate the care taken by RingCentral to ensure that only high-quality apps are allowed into our production environment.
+Congradulations on creating your first RingCentral application. The last step is to publish your application. We recommend [going through this process](../../basics/app-gallery.md) for your first application so you can understand the steps to take in the future, but also to come to appreciate the care taken by RingCentral to ensure that only high-quality apps are allowed into our production environment.

--- a/docs/sms/quick-start/node.md
+++ b/docs/sms/quick-start/node.md
@@ -97,4 +97,4 @@ $ node sms.js
 
 ## Publish Your App
 
-Congratulations on creating your first RingCentral application. The last step is to publish your application. We recommend [going through this process](../basics/publish) for your first application so you can understand the steps to take in the future, but also to come to appreciate the care taken by RingCentral to ensure that only high-quality apps are allowed into our production environment.
+Congratulations on creating your first RingCentral application. The last step is to publish your application. We recommend [going through this process](../../basics/app-gallery.md) for your first application so you can understand the steps to take in the future, but also to come to appreciate the care taken by RingCentral to ensure that only high-quality apps are allowed into our production environment.

--- a/docs/sms/quick-start/php.md
+++ b/docs/sms/quick-start/php.md
@@ -86,4 +86,4 @@ $ php sms.php
 
 ## Publish Your App
 
-Congratulations on creating your first RingCentral application. The last step is to publish your application. We recommend [going through this process](../basics/publish) for your first application so you can understand the steps to take in the future, but also to come to appreciate the care taken by RingCentral to ensure that only high-quality apps are allowed into our production environment.
+Congratulations on creating your first RingCentral application. The last step is to publish your application. We recommend [going through this process](../../basics/app-gallery.md) for your first application so you can understand the steps to take in the future, but also to come to appreciate the care taken by RingCentral to ensure that only high-quality apps are allowed into our production environment.

--- a/docs/sms/quick-start/python.md
+++ b/docs/sms/quick-start/python.md
@@ -82,4 +82,4 @@ $ python sms.py
 
 ## Publish Your App
 
-Congratulations on creating your first RingCentral application. The last step is to publish your application. We recommend [going through this process](../basics/publish) for your first application so you can understand the steps to take in the future, but also to come to appreciate the care taken by RingCentral to ensure that only high-quality apps are allowed into our production environment.
+Congratulations on creating your first RingCentral application. The last step is to publish your application. We recommend [going through this process](../../basics/app-gallery.md) for your first application so you can understand the steps to take in the future, but also to come to appreciate the care taken by RingCentral to ensure that only high-quality apps are allowed into our production environment.

--- a/docs/team-messaging/quick-start/node.md
+++ b/docs/team-messaging/quick-start/node.md
@@ -132,4 +132,4 @@ Type "ping" and see what happens.
 
 ## Publish Your App
 
-Congradulations on creating your first RingCentral application. The last step is to publish your application. We recommend [going through this process](../basics/publish) for your first application so you can understand the steps to take in the future, but also to come to appreciate the care taken by RingCentral to ensure that only high-quality apps are allowed into our production environment.
+Congradulations on creating your first RingCentral application. The last step is to publish your application. We recommend [going through this process](../../basics/app-gallery.md) for your first application so you can understand the steps to take in the future, but also to come to appreciate the care taken by RingCentral to ensure that only high-quality apps are allowed into our production environment.

--- a/docs/team-messaging/quick-start/python.md
+++ b/docs/team-messaging/quick-start/python.md
@@ -117,4 +117,4 @@ FLASK_ENV=development
 
 ## Publish Your App
 
-Congradulations on creating your first RingCentral application. The last step is to publish your application. We recommend [going through this process](../basics/publish) for your first application so you can understand the steps to take in the future, but also to come to appreciate the care taken by RingCentral to ensure that only high-quality apps are allowed into our production environment.
+Congradulations on creating your first RingCentral application. The last step is to publish your application. We recommend [going through this process](../../basics/app-gallery.md) for your first application so you can understand the steps to take in the future, but also to come to appreciate the care taken by RingCentral to ensure that only high-quality apps are allowed into our production environment.

--- a/docs/voice/quick-start/ringout/c-sharp.md
+++ b/docs/voice/quick-start/ringout/c-sharp.md
@@ -94,4 +94,4 @@ You are almost done. Now run your app from Visual Studio.
 
 ## Publish Your App
 
-Congratulations on creating your first RingCentral application. The last step is to publish your application. We recommend [going through this process](../basics/publish) for your first application so you can understand the steps to take in the future, but also to come to appreciate the care taken by RingCentral to ensure that only high-quality apps are allowed into our production environment.
+Congratulations on creating your first RingCentral application. The last step is to publish your application. We recommend [going through this process](../../../basics/app-gallery.md) for your first application so you can understand the steps to take in the future, but also to come to appreciate the care taken by RingCentral to ensure that only high-quality apps are allowed into our production environment.

--- a/docs/voice/quick-start/ringout/explorer.md
+++ b/docs/voice/quick-start/ringout/explorer.md
@@ -42,4 +42,4 @@ TODO
 
 ## Publish Your App
 
-Congradulations on creating your first RingCentral application. The last step is to publish your application. We recommend [going through this process](../basics/publish) for your first application so you can understand the steps to take in the future, but also to come to appreciate the care taken by RingCentral to ensure that only high-quality apps are allowed into our production environment.
+Congradulations on creating your first RingCentral application. The last step is to publish your application. We recommend [going through this process](../../../basics/app-gallery.md) for your first application so you can understand the steps to take in the future, but also to come to appreciate the care taken by RingCentral to ensure that only high-quality apps are allowed into our production environment.

--- a/docs/voice/quick-start/ringout/node.md
+++ b/docs/voice/quick-start/ringout/node.md
@@ -97,4 +97,4 @@ $ node ringout.js
 
 ## Publish Your App
 
-Congratulations on creating your first RingCentral application. The last step is to publish your application. We recommend [going through this process](../basics/publish) for your first application so you can understand the steps to take in the future, but also to come to appreciate the care taken by RingCentral to ensure that only high-quality apps are allowed into our production environment.
+Congratulations on creating your first RingCentral application. The last step is to publish your application. We recommend [going through this process](../../../basics/app-gallery.md) for your first application so you can understand the steps to take in the future, but also to come to appreciate the care taken by RingCentral to ensure that only high-quality apps are allowed into our production environment.

--- a/docs/voice/quick-start/ringout/php.md
+++ b/docs/voice/quick-start/ringout/php.md
@@ -88,4 +88,4 @@ $ php ringout.php
 
 ## Publish Your App
 
-Congratulations on creating your first RingCentral application. The last step is to publish your application. We recommend [going through this process](../basics/publish) for your first application so you can understand the steps to take in the future, but also to come to appreciate the care taken by RingCentral to ensure that only high-quality apps are allowed into our production environment.
+Congratulations on creating your first RingCentral application. The last step is to publish your application. We recommend [going through this process](../../../basics/app-gallery.md) for your first application so you can understand the steps to take in the future, but also to come to appreciate the care taken by RingCentral to ensure that only high-quality apps are allowed into our production environment.

--- a/docs/voice/quick-start/ringout/python.md
+++ b/docs/voice/quick-start/ringout/python.md
@@ -73,4 +73,4 @@ $ python ringout.py
 
 ## Publish Your App
 
-Congratulations on creating your first RingCentral application. The last step is to publish your application. We recommend [going through this process](../basics/publish) for your first application so you can understand the steps to take in the future, but also to come to appreciate the care taken by RingCentral to ensure that only high-quality apps are allowed into our production environment.
+Congratulations on creating your first RingCentral application. The last step is to publish your application. We recommend [going through this process](../../../basics/app-gallery.md) for your first application so you can understand the steps to take in the future, but also to come to appreciate the care taken by RingCentral to ensure that only high-quality apps are allowed into our production environment.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,9 +6,9 @@ edit_uri: tree/bootstrap-vertical-nav/docs
 docs_dir: docs
 
 plugins:
-  - git-committers:
-      repository: ringcentral/ringcentral-api-docs
-      branch: bootstrap-vertical-nav
+#  - git-committers:
+#      repository: ringcentral/ringcentral-api-docs
+#      branch: bootstrap-vertical-nav
   - bootstrap-tables
 #  - markdown-filter
 #  - search-path:


### PR DESCRIPTION
### Problem

The "going through this process" link in all quick start pages is incorrect, which link to a page does not exist.

### Changes

Update the "going through this process" link to `basics/app-gallery.md` with corresponding relative path prefix.