### PR TITLE
Clarified HTTP Example 2 as HTTP2 is confusing

### DIFF
--- a/docs/messaging/sms/high-volume/sending-highvolume-sms.md
+++ b/docs/messaging/sms/high-volume/sending-highvolume-sms.md
@@ -155,7 +155,7 @@ The code samples above would all produce a response that would appear similar to
     }
     ```
 
-=== "HTTP2"
+=== "HTTP (example 2)"
     ```http
     POST /restapi/v1.0/account/~/a2p-sms/batch
     Content-Type: application/json


### PR DESCRIPTION
Renamed "HTTP2" to "HTTP (example 2) as HTTP2 can easily be confused with HTTP/2 implying streaming capabilities or that it does not work with HTTP/1.1