### PR TITLE
Fixed broken link and heading issue for API Guide Doc

### DIFF
--- a/docs/analytics/api-guide.md
+++ b/docs/analytics/api-guide.md
@@ -2,7 +2,7 @@ no_breadcrumb:true
 
 # API Data Guide
 
-## Call performance aggregate API:
+## Call Performance Aggregate API:
 
 **API Endpoint**
 
@@ -218,7 +218,7 @@ Supported time interval values are Hour, Day, Week, and Month. For example, this
 
 Compared to aggregate end point, 1 additional point that needs to be answered in timeline endpoint is the TimeFrame (preferred interval). 
 
-#### HTTP Request
+### HTTP Request
 
 - Grouping: Allows users to specify data scope. All the data retrieved will represent the portion of the calls that involved the specified GroupBy type. GroupBy types cannot be mixed in one request, there can only be one type. In API request structure, it can be specified in groupby section on top. This is similar to aggregate end point along with providing data at different timeframe split.
 

--- a/docs/analytics/troubleshooting.md
+++ b/docs/analytics/troubleshooting.md
@@ -4,13 +4,11 @@ no_breadcrumb:true
 
 ### Is there an SDK for my favorite programming language ?
 
-Yes, RingCentral offers developers a number of [SDKs for the most popular programming languages](../../sdks/). 
-
-During our beta however, Java and C# programmers will need to call Analytics API endpoints directly. When this API is made available publicly, our Java and C# SDKs will be updated as well. 
+Yes, RingCentral offers developers a number of [SDKs for the most popular programming languages](https://developers.ringcentral.com/guide/sdks). 
 
 ### What permission does my application need to have ?
 
-Your application needs to have 'Analytics' permission. If you are using an application that doesn't have that permission, you can reach out to our support team with your Application's Client ID and request 'Analytics' permission to be added.
+Your application needs to have 'Analytics' permission. If you are using an application that doesn't have that permission, you can [reach out to our support team](https://developers.ringcentral.com/support/create-case) with your Application's Client ID and request 'Analytics' permission to be added.
 
 ### How is LOB Analytics API different than Call Log API ? 
 


### PR DESCRIPTION
- Fixed JIRA Issue: https://jira.ringcentral.com/browse/DPW-15700

- Made a change to API Guide Heading and I can see the content outline on localhost. This needs to be tested again in the testing environment, not sure why it's not showing the content outline properly. 

- Seeking / help from @byrnereese on this https://jira.ringcentral.com/browse/DPW-15699 and https://jira.ringcentral.com/browse/DPW-15698