### PR TITLE
Fixed verify bug in verify event sample code

### DIFF
--- a/code-samples/team-messaging/verify-event.js
+++ b/code-samples/team-messaging/verify-event.js
@@ -1,14 +1,20 @@
 const SHARED_SECRET = "abcdefghijklmnopqrstuvwxyz"
 api.post('/hook', function (req, res) {
- var signature = req.get('X-Glip-Signature', 'sha1=')
+ var signature = req.get('X-Glip-Signature');
  var bodyCrypted = require('crypto')
-  .createHmac('sha1', SHARED_SECRET)
-  .update(JSON.stringify(req.body))
-  .digest('hex')
+     .createHmac(
+         'sha1',
+         SHARED_SECRET 
+     )
+     .update(JSON.stringify(req.body))
+     .digest()
+     .toString('hex');
+
  if (bodyCrypted !== signature) {
-  res.status(401).send()
-  return
+     res.status(401).send();
+     return;
  }
+
  console.log('Webhook received')
  // code continues 
 })


### PR DESCRIPTION
The previous code didn't have `.toString('hex');` and `bodyCrypted` was not being converted to a Buffer correctly. This code should work without error