### PR TITLE
Updated sample, now just set usePKCE to true

### DIFF
--- a/code-samples/auth/login-url-pkce.js
+++ b/code-samples/auth/login-url-pkce.js
@@ -1,25 +1,4 @@
 const RC = require('@ringcentral/sdk').SDK
-import {randomBytes} from 'crypto';
-import {createHash} from 'crypto';
-
-function _generateCodeVerifier() {
-    let codeVerifier: any = randomBytes(32);
-    codeVerifier = codeVerifier
-	.toString('base64')
-	.replace(/\+/g, '-')
-	.replace(/\//g, '_')
-	.replace(/=/g, '');
-    return codeVerifier;
-}
-
-let codeVerifier = this._generateCodeVerifier();
-let codeChallenge = createHash('sha256')
-    .update(codeVerifier)
-    .digest()
-    .toString('base64')
-    .replace(/\+/g, '-')
-    .replace(/\//g, '_')
-    .replace(/=/g, '');
 
 var rcsdk = new RC({
     'server':       process.env.RC_SERVER_URL,
@@ -31,6 +10,5 @@ var platform = rcsdk.platform();
 
 console.log( "Login URL: ", platform.loginUrl({
     "state": "1234567890",
-    "code_challenge": codeChallenge,
-    "code_challenge_method": "S256"
+    "usePKCE": true
 }) )


### PR DESCRIPTION
Hi , I found parts of the documentation that seem outdated.

[LoginUrlOptions](https://github.com/ringcentral/ringcentral-js/blob/master/sdk/src/platform/Platform.ts#L890) now provides [usePKCE (boolean)](https://github.com/ringcentral/ringcentral-js/blob/master/sdk/src/platform/Platform.ts#L899) property, so that developers do not need to generate and set `code_verifier` and `code_challenge`. 😃

see here please 👉 https://github.com/ringcentral/ringcentral-js/blob/master/sdk/src/platform/Platform.ts#L291