### PR TITLE
fix: BA interactive api link change

### DIFF
--- a/docs/analytics/aggregate.md
+++ b/docs/analytics/aggregate.md
@@ -14,7 +14,7 @@ For more information, please refer to the [overview section](index.md).
 
 ## Composing a request using RingCentral API Reference
 
-One can use our [interactive API Reference](https://developers.ringcentral.com/api-reference/Business-Analytics/aggregatePerformanceReportCalls) to not only create API Request but also run it interactively and see the response.
+One can use our [interactive API Reference](https://developers.ringcentral.com/api-reference/Business-Analytics/analyticsCallsAggregationFetch) to not only create API Request but also run it interactively and see the response.
 
 ## API Definition Guide
 


### PR DESCRIPTION
We found out that current link to "interactive API Reference" if using currently not existing method, so the api-reference site redirects to the main page

this didn't work: https://developers.ringcentral.com/api-reference/Business-Analytics/aggregatePerformanceReportCalls

this one works: https://developers.ringcentral.com/api-reference/Business-Analytics/analyticsCallsAggregationFetch