### PR TITLE
Authorize uri params change

### DIFF
--- a/code-samples/auth/quick-start/ruby/main_controller.rb
+++ b/code-samples/auth/quick-start/ruby/main_controller.rb
@@ -15,7 +15,7 @@ class MainController < ActionController::Base
                          ENV['RC_SERVER_URL'] )
 
   def login
-    base_url = $rc.authorize_uri(REDIRECT_URL, "initialState")
+    base_url = $rc.authorize_uri(REDIRECT_URL)
     @authorize_uri = base_url
   end
 


### PR DESCRIPTION
In SDK now authorize_uri method params have been changed that's why facing an issue while setup.Fixing these params issues.

New method:

 def authorize_uri(redirect_uri, hash = {})
    hash[:response_type] = 'code'
    hash[:redirect_uri] = redirect_uri
    hash[:client_id] = @client_id
    uri = Addressable::URI.parse(@server) + '/restapi/oauth/authorize'
    uri.query_values = hash
    uri.to_s
  end