### PR TITLE
Improvement: Fix the allowed file extensions list for MMS

### DIFF
--- a/docs/messaging/sms/sending-images.md
+++ b/docs/messaging/sms/sending-images.md
@@ -22,16 +22,15 @@ RingCentral platform supported MMS content types
 | | video/quicktime | .mov/.qt |
 | | video/webm | .webm |
 | | video/ogg  | .ogg |
-| | video/3gpp | .3gp |
 | `Audio` | audio/mpeg | .mp3 |
 | | audio/mp4 | .m4a |
 | | audio/ogg | .oga |
 | | audio/wav | .wav |
-| | audio/arm | .arm |
+| | audio/amr | .amr |
 | | audio/3gpp | .3gp |
 | `V-Card` | text/vcard | .vcf/.vcard |
 | `Compressed file` | application/zip | .zip |
-| | application/gzip | .gzip |
+| | application/gzip | .gzip/.gz |
 | `Document` | application/rtf | .rtf |
 | | application/pdf | .pdf |
 | | text/html | .html |


### PR DESCRIPTION
## :pencil2: Change(s)
- Remove duplicated mention of `.3gp`
- I may be wrong but `audio/arm` doesn't exist and should be `audio/amr` instead (see https://github.com/github/mime-types/blob/master/lib/mime/types/audio)
- Added `.gz` along with `.gzip`