### PR TITLE
Add thread messages documentation

### DIFF
--- a/code-samples/team-messaging/threaded-posts.js
+++ b/code-samples/team-messaging/threaded-posts.js
@@ -1,0 +1,61 @@
+const RC = require('@ringcentral/sdk').SDK
+require('dotenv').config();
+
+var rcsdk = new RC({
+    'server':       process.env.RC_SERVER_URL,
+    'clientId':     process.env.RC_APP_CLIENT_ID,
+    'clientSecret': process.env.RC_APP_CLIENT_SECRET
+});
+var platform = rcsdk.platform();
+platform.login({ 'jwt':  process.env.RC_USER_JWT })
+
+platform.on(platform.events.loginSuccess, () => {
+  create_threaded_posts()
+})
+
+async function create_threaded_posts() {
+  try {
+    let chatId = await get_personal_chat_id()
+    let parentPost = await create_post(chatId, {
+      text: "Thread parent post"
+    })
+    console.log("Parent post ID: " + parentPost.id)
+
+    let reply = await create_post(chatId, {
+      text: "First reply in the thread",
+      parentPostId: parentPost.id
+    })
+    console.log("Reply post ID: " + reply.id)
+    console.log("Thread ID: " + reply.threadId)
+
+    let threadPosts = await list_thread_posts(chatId, reply.threadId)
+    console.log("Posts in thread:")
+    threadPosts.records.forEach((post) => {
+      console.log(`- ${post.id}: ${post.text}`)
+    })
+  } catch (e) {
+    console.log(e.message)
+  }
+}
+
+async function get_personal_chat_id() {
+  let endpoint = "/team-messaging/v1/chats"
+  let resp = await platform.get(endpoint, { type: 'Personal' })
+  let jsonObj = await resp.json()
+  if (jsonObj.records.length === 0) {
+    throw new Error("Personal chat not found")
+  }
+  return jsonObj.records[0].id
+}
+
+async function create_post(chatId, bodyParams) {
+  let endpoint = `/team-messaging/v1/chats/${chatId}/posts`
+  let resp = await platform.post(endpoint, bodyParams)
+  return await resp.json()
+}
+
+async function list_thread_posts(chatId, threadId) {
+  let endpoint = `/team-messaging/v1/chats/${chatId}/threads/${threadId}/posts`
+  let resp = await platform.get(endpoint, { recordCount: 30 })
+  return await resp.json()
+}

--- a/docs/basics/api-index.md
+++ b/docs/basics/api-index.md
@@ -10835,6 +10835,63 @@ In case the feature is available for the current user, <code>"available": true</
 <tr>
       <td class="method">
         
+        <a href="#" class="collapsed" data-bs-toggle="collapse" data-target="#readGlipThreadPostsNew" aria-expanded="true" aria-controls="readGlipThreadPostsNew">List Thread Posts</a> 
+        
+      </td>
+      <td class="description"><p>Returns a list of posts from the specified thread in a chat.</p></td>
+    </tr>
+    <tr>
+      <td class="endpoint" colspan="2">
+        <p>GET /team-messaging/v1/chats/{chatId}/threads/{threadId}/posts <a href="https://developers.ringcentral.com/api-reference/Posts/readGlipThreadPostsNew" class="external-link"><i class="fa fa-share"></i></a></p>
+	<div id="readGlipThreadPostsNew" class="collapse" aria-labelledby="readGlipThreadPostsNew">
+
+	  <table class="table api-index">
+	    <thead>
+	      <tr>
+	        <th scope="col">Name</th>
+		<th scope="col">Type</th>
+		<th scope="col">Default</th>
+		<th scope="col">Required</th>
+		<th scope="col">Description</th>
+              </tr>
+            </thead>
+            <tbody>
+<tr>
+	      <td class="n">chatId</td>
+	      <td class="t">string</td>
+	      <td class="d"></td>
+	      <td class="r">True</td>
+	      <td class="de">Internal identifier of a chat</td>
+            </tr>
+<tr>
+	      <td class="n">threadId</td>
+	      <td class="t">string</td>
+	      <td class="d"></td>
+	      <td class="r">True</td>
+	      <td class="de">Identifier of a thread, in case post is a part of a thread</td>
+            </tr>
+<tr>
+	      <td class="n">pageToken</td>
+	      <td class="t">string</td>
+	      <td class="d"></td>
+	      <td class="r">False</td>
+	      <td class="de">Pagination token.</td>
+            </tr>
+<tr>
+	      <td class="n">recordCount</td>
+	      <td class="t">integer</td>
+	      <td class="d">30</td>
+	      <td class="r">False</td>
+	      <td class="de">Max number of posts to be fetched by one request (not more than 250)</td>
+            </tr>
+</tbody>
+          </table>
+</div>
+      </td>
+    </tr>
+<tr>
+      <td class="method">
+        
         <a href="#" class="collapsed" data-bs-toggle="collapse" data-target="#listGlipGroupPosts" aria-expanded="true" aria-controls="listGlipGroupPosts">Get Group Posts</a> 
         
       </td>

--- a/docs/team-messaging/posting/threads.md
+++ b/docs/team-messaging/posting/threads.md
@@ -17,7 +17,7 @@ Create the first reply to a post by passing the parent post ID in the `parentPos
 
 If `parentPostId` identifies a reply that is already in a thread, the new post is added to the original parent post's thread.
 
-## Adding a reply to threads
+## Adding a reply to a thread
 
 If your app already has a thread ID, you can add a reply by passing `threadId` instead.
 

--- a/docs/team-messaging/posting/threads.md
+++ b/docs/team-messaging/posting/threads.md
@@ -1,0 +1,61 @@
+# Posting thread messages via the API
+
+Team Messaging posts can be grouped into threads. A threaded reply is still a post in the same chat, but the post response includes thread metadata that lets your app find the parent post and retrieve the other posts in the thread.
+
+Use threaded posts when a bot or app needs to keep follow-up messages attached to a specific conversation inside a chat.
+
+## Creating a thread reply
+
+Create the first reply to a post by passing the parent post ID in the `parentPostId` request property when you call [Create Post](https://developers.ringcentral.com/api-reference/Posts/createGlipPostNew).
+
+```json
+{
+  "text": "First reply in the thread",
+  "parentPostId": "1234567890"
+}
+```
+
+If `parentPostId` identifies a reply that is already in a thread, the new post is added to the original parent post's thread.
+
+If your app already has a thread ID, you can add a reply by passing `threadId` instead.
+
+```json
+{
+  "text": "Reply using a thread ID",
+  "threadId": "9876543210"
+}
+```
+
+Use one of `parentPostId` or `threadId` for a threaded reply. To create a regular top-level post, omit both fields.
+
+## Reading thread metadata
+
+Post responses from [Create Post](https://developers.ringcentral.com/api-reference/Posts/createGlipPostNew), [Get Post](https://developers.ringcentral.com/api-reference/Posts/readGlipPostNew), [Update Post](https://developers.ringcentral.com/api-reference/Posts/patchGlipPostNew), and [List Posts](https://developers.ringcentral.com/api-reference/Posts/readGlipPostsNew) can include these thread fields:
+
+| Field | Description |
+|-|-|
+| `isParent` | Returned for a post that is the parent post of a thread. |
+| `parentPostId` | The parent post ID when the post belongs to a thread. |
+| `threadId` | The thread ID shared by posts in the same thread. |
+
+## Listing posts in a thread
+
+Call [List Thread Posts](https://developers.ringcentral.com/api-reference/Posts/readGlipThreadPostsNew) to fetch posts that belong to a specific thread.
+
+```http
+GET /team-messaging/v1/chats/{chatId}/threads/{threadId}/posts?recordCount=30
+```
+
+The response uses the same Team Messaging pagination model as other list endpoints. If the response contains `navigation.nextPageToken` or `navigation.prevPageToken`, pass the token as the `pageToken` query parameter in the next request.
+
+```http
+GET /team-messaging/v1/chats/{chatId}/threads/{threadId}/posts?pageToken={pageToken}
+```
+
+## Example
+
+The following example finds the authenticated user's personal chat, creates a parent post, creates a threaded reply using `parentPostId`, and then lists posts from the returned `threadId`.
+
+```javascript
+{! code-samples/team-messaging/threaded-posts.js !}
+```

--- a/docs/team-messaging/posting/threads.md
+++ b/docs/team-messaging/posting/threads.md
@@ -17,6 +17,8 @@ Create the first reply to a post by passing the parent post ID in the `parentPos
 
 If `parentPostId` identifies a reply that is already in a thread, the new post is added to the original parent post's thread.
 
+## Adding a reply to threads
+
 If your app already has a thread ID, you can add a reply by passing `threadId` instead.
 
 ```json
@@ -56,6 +58,8 @@ GET /team-messaging/v1/chats/{chatId}/threads/{threadId}/posts?pageToken={pageTo
 
 The following example finds the authenticated user's personal chat, creates a parent post, creates a threaded reply using `parentPostId`, and then lists posts from the returned `threadId`.
 
-```javascript
-{! code-samples/team-messaging/threaded-posts.js !}
-```
+=== "JavaScript"
+
+    ```javascript
+    {!> code-samples/team-messaging/threaded-posts.js !}
+    ```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -198,6 +198,7 @@ nav:
 
     - 'Posting via REST API':
       - 'Posting messages': 'team-messaging/posting/index.md'
+      - 'Posting thread messages': 'team-messaging/posting/threads.md'
       - 'Posting cards': 'team-messaging/posting/cards.md'
       - 'Posting notes': 'team-messaging/posting/notes.md'
       - 'Posting tasks': 'team-messaging/posting/tasks.md'


### PR DESCRIPTION
## Summary

  Add Team Messaging documentation for posting thread messages.

  ## Changes

  - Added a new guide page: `Posting thread messages via the API`
  - Added navigation entry under `Team Messaging > Posting via REST API`
  - Added a JavaScript SDK sample for:
    - creating a parent post
    - creating a thread reply using `parentPostId`
    - listing posts in a thread using `threadId`
  - Added `List Thread Posts` to the API quick index